### PR TITLE
Feat: Add cleaning script and task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,6 +2,29 @@
 	"version": "2.0.0",
 	"tasks": [
     {
+      "type": "shell",
+      "command": "scripts/clean.sh",
+      "label": "Clean",
+      "detail": "Clean all or some parts of the repo",
+      "args": [
+        "${input:cleanType}"
+      ],
+      "isBackground": true,
+      "presentation": {
+        "echo": false,
+        "reveal": "never",
+        "focus": false,
+        "panel": "new",
+        "showReuseMessage": true,
+        "clear": false,
+        "close": true
+      },
+      "icon": {
+        "color": "terminal.ansiRed",
+        "id": "clear-all"
+      }
+    },
+    {
       "type": "npm",
       "script": "dev",
       "problemMatcher": [],
@@ -104,5 +127,17 @@
         "instanceLimit": 10,
       }
     },
+  ],
+  "inputs": [
+    {
+      "id": "cleanType",
+      "type": "pickString",
+      "description": "Choose the type of cleaning",
+      "options": [
+        "all",
+        "build",
+        "dependencies"
+      ]
+    }
   ]
 }

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+main() {
+  type=$1
+  case $type in
+    all)
+      rm -rf lib node_modules .tsbuildinfo types
+    ;;
+
+    build)
+      rm -rf lib .tsbuildinfo types
+    ;;
+
+    dependencies)
+      rm -rf node_modules
+    ;;
+
+    *)
+      echo "Error: Unrecognized clean type"
+      exit 1
+      ;;
+  esac
+}
+
+main $1


### PR DESCRIPTION
- Implement `scripts/clean.sh`: a script that can clean the repo in
  different ways.
- Add task for easily calling `scripts/clean.sh` with predefined inputs.
