### PR TITLE
Fix #8: Dev monitor quitting unexpectedly

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "types": "types",
   "private": true,
   "scripts": {
-    "dev": "ts-node-dev src/index.ts",
+    "dev": "ts-node-dev --respawn src/index.ts",
     "prod": "yarn build && yarn start",
     "start": "node .",
     "build": "tsc",


### PR DESCRIPTION
- Add `--respawn` arg to `dev` task in `package.json` so that it waits
  for processes that exit as well. This way this task can be used for
  short codes that do exit.
