### PR TITLE
Chore: devcontainer image version

### DIFF
--- a/.docker/docker-compose.dev.yml
+++ b/.docker/docker-compose.dev.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   node-ts-repo-template:
-    image: utkusarioglu/node-devcontainer:19-slim.0.4
+    image: utkusarioglu/node-devcontainer:19-slim.0.5
     volumes:
       - type: bind
         source: ..


### PR DESCRIPTION
- Upgrade devcontainer image version to 19-slim.0.5. This version
  features jq.
