### PR TITLE
Chore: Add prettier vscode ext, es target change

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,10 @@
           "activityBar.background": "#ff0000",
           "activityBar.foreground": "#000000"
         }
-      }
+      },
+      "extensions": [
+        "esbenp.prettier-vscode"
+      ]
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
     /* Language and Environment */
-    "target": "ES2023", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "ES2022", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     "experimentalDecorators": true, /* Enable experimental support for TC39 stage 2 draft decorators. */


### PR DESCRIPTION
- Add prettier extension for vscode devcontainer definition.
- Downgrade es target to ES2022 because jest in its current version
  doesn't like es2023.
